### PR TITLE
Extend BuildPropertiesFileBuilder and WorkspaceHelper

### DIFF
--- a/org.moflon.core.plugins/src/org/moflon/core/plugins/BuildPropertiesFileBuilder.java
+++ b/org.moflon.core.plugins/src/org/moflon/core/plugins/BuildPropertiesFileBuilder.java
@@ -13,47 +13,69 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
 import org.moflon.core.utilities.WorkspaceHelper;
 
-public class BuildPropertiesFileBuilder
-{
+/**
+ * Utility class for creating build.properties file.
+ */
+public class BuildPropertiesFileBuilder {
 
-   private static final String BUILD_PROPERTIES_NAME = "build.properties";
+	private static final String BUILD_PROPERTIES_NAME = "build.properties";
 
-   public void createBuildProperties(final IProject currentProject, final IProgressMonitor monitor) throws CoreException
-   {
-      try
-      {
-         final SubMonitor subMon = SubMonitor.convert(monitor, "Creating build.properties", 2);
+	/**
+	 * Creates a build.properties file in the given project with the eMoflon default
+	 * build properties.
+	 * 
+	 * @param currentProject
+	 *            the project
+	 * @param monitor
+	 *            the progress monitor
+	 * @throws CoreException
+	 */
+	public void createBuildProperties(final IProject currentProject, final IProgressMonitor monitor)
+			throws CoreException {
+		Properties buildProperties = new Properties();
+		buildProperties.put("bin.includes", "META-INF/, bin/, model/, plugin.xml, moflon.properties.xmi");
+		buildProperties.put("source..", "src/,gen/");
+		buildProperties.put("src.excludes", "injection/");
+		buildProperties.put("output..", "bin/");
+		this.createBuildProperties(currentProject, monitor, buildProperties);
+	}
 
-         IFile file = getBuildPropertiesFile(currentProject);
-         if (file.exists())
-         {
-            // Do not touch existing build.properties
-            subMon.worked(2);
-         } else
-         {
-            Properties buildProperties = new Properties();
-            buildProperties.put("bin.includes", "META-INF/, bin/, model/, plugin.xml, moflon.properties.xmi");
-            buildProperties.put("source..", "src/,gen/");
-            buildProperties.put("src.excludes", "injection/");
-            buildProperties.put("output..", "bin/");
+	/**
+	 * Creates a build.properties file in the given project with the the given build
+	 * properties.
+	 * 
+	 * @param currentProject
+	 *            the project
+	 * @param monitor
+	 *            the progress monitor
+	 * @param buildProperties
+	 *            the build properties to set
+	 * @throws CoreException
+	 */
+	public void createBuildProperties(final IProject currentProject, final IProgressMonitor monitor,
+			final Properties buildProperties) throws CoreException {
+		try {
+			final SubMonitor subMon = SubMonitor.convert(monitor, "Creating build.properties", 2);
 
-            subMon.worked(1);
+			IFile file = getBuildPropertiesFile(currentProject);
+			if (file.exists()) {
+				// Do not touch existing build.properties
+				subMon.worked(2);
+			} else {
+				subMon.worked(1);
 
-            final ByteArrayOutputStream stream = new ByteArrayOutputStream();
-            buildProperties.store(stream, "");
+				final ByteArrayOutputStream stream = new ByteArrayOutputStream();
+				buildProperties.store(stream, "");
 
-            WorkspaceHelper.addFile(currentProject, BUILD_PROPERTIES_NAME, stream.toString(), subMon.split(1));
-         }
-      } catch (IOException e)
-      {
-         throw new CoreException(
-               new Status(IStatus.ERROR, WorkspaceHelper.getPluginId(getClass()), "Error while creating build.properties: " + e.getMessage()));
-      }
-   }
+				WorkspaceHelper.addFile(currentProject, BUILD_PROPERTIES_NAME, stream.toString(), subMon.split(1));
+			}
+		} catch (IOException e) {
+			throw new CoreException(new Status(IStatus.ERROR, WorkspaceHelper.getPluginId(getClass()),
+					"Error while creating build.properties: " + e.getMessage()));
+		}
+	}
 
-   public IFile getBuildPropertiesFile(final IProject currentProject)
-   {
-      return currentProject.getFile(BUILD_PROPERTIES_NAME);
-   }
-
+	public IFile getBuildPropertiesFile(final IProject currentProject) {
+		return currentProject.getFile(BUILD_PROPERTIES_NAME);
+	}
 }

--- a/org.moflon.core.utilities/src/org/moflon/core/utilities/WorkspaceHelper.java
+++ b/org.moflon.core.utilities/src/org/moflon/core/utilities/WorkspaceHelper.java
@@ -28,6 +28,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.emf.common.util.URI;
 import org.eclipse.pde.core.plugin.IPluginModelBase;
 import org.eclipse.pde.core.plugin.PluginRegistry;
 import org.osgi.framework.Bundle;
@@ -675,4 +676,35 @@ public class WorkspaceHelper
    	}
    }
 
+	/**
+	 * Returns a list of URIs to .ecore files of eMoflon EMF Projects in the
+	 * workspace.
+	 * 
+	 * @param excludeURIs
+	 *            the URIs to exclude from the list
+	 * @return the list of URIs to ecore files
+	 */
+	public static List<String> getEcoreURIsInWorkspace(final List<String> excludeURIs) {
+		ArrayList<String> uris = new ArrayList<String>();
+		Arrays.stream(ResourcesPlugin.getWorkspace().getRoot().getProjects()) //
+				.filter(project -> hasNature(project, "org.moflon.emf.build.MoflonEmfNature")) // only EMF Projects
+				.forEach(project -> {
+					IFolder modelFolder = getModelFolder(project);
+					if (modelFolder.exists()) {
+						try {
+							IResource[] members = modelFolder.members();
+							Arrays.stream(members).filter(m -> m.getFileExtension().equals("ecore")).forEach(m -> {
+								URI uri = URI.createPlatformResourceURI(m.getFullPath().toString(), true);
+								uris.add(uri.toString());
+							});
+						} catch (CoreException e) {
+							// Do nothing.
+						}
+					}
+				});
+		if (excludeURIs != null) {
+			uris.removeAll(excludeURIs);
+		}
+		return uris;
+	}
 }

--- a/projectSet.psf
+++ b/projectSet.psf
@@ -25,32 +25,32 @@
 <project reference="1.0,https://github.com/eMoflon/emoflon-core.git,master,org.moflon.emf.ui"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-core.git,master,org.moflon.git.ui"/>
 </provider>
-<workingSets editPageId="org.eclipse.jdt.ui.JavaWorkingSetPage" id="1518877391885_3" label="code generator" name="code generator">
+<workingSets editPageId="org.eclipse.jdt.ui.JavaWorkingSetPage" id="1518877391885_3" label="core-code-generator" name="code generator">
 <item elementID="=org.moflon.emf.build" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
 <item elementID="=org.moflon.emf.codegen" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
 <item elementID="=org.moflon.core.build.tests" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
 <item elementID="=org.moflon.core.build" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
 </workingSets>
-<workingSets editPageId="org.eclipse.jdt.ui.JavaWorkingSetPage" id="1518877419851_4" label="deployment" name="deployment">
+<workingSets editPageId="org.eclipse.jdt.ui.JavaWorkingSetPage" id="1518877419851_4" label="core-deployment" name="deployment">
 <item elementID="=org.moflon.core.branding" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
 <item factoryID="org.eclipse.ui.internal.model.ResourceFactory" path="/org.moflon.core.releng.target" type="4"/>
 <item factoryID="org.eclipse.ui.internal.model.ResourceFactory" path="/org.moflon.core.feature" type="4"/>
 <item factoryID="org.eclipse.ui.internal.model.ResourceFactory" path="/org.moflon.core.releng.updatesite" type="4"/>
 </workingSets>
-<workingSets editPageId="org.eclipse.jdt.ui.JavaWorkingSetPage" id="1518877489367_5" label="ide" name="ide">
+<workingSets editPageId="org.eclipse.jdt.ui.JavaWorkingSetPage" id="1518877489367_5" label="core-ide" name="ide">
 <item elementID="=org.moflon.emf.ui" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
 <item elementID="=org.moflon.core.ui" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
 <item elementID="=org.moflon.core.ui.autosetup.tests" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
 <item elementID="=org.moflon.core.ui.autosetup" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
 <item elementID="=org.moflon.git.ui" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
 </workingSets>
-<workingSets editPageId="org.eclipse.jdt.ui.JavaWorkingSetPage" id="1518877351561_2" label="injection" name="injection">
+<workingSets editPageId="org.eclipse.jdt.ui.JavaWorkingSetPage" id="1518877351561_2" label="core-injection" name="injection">
 <item elementID="=org.moflon.emf.injection.ui" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
 <item elementID="=org.moflon.emf.injection" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
 <item elementID="=org.moflon.emf.injection.tests" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
 <item elementID="=org.moflon.emf.injection.ide" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
 </workingSets>
-<workingSets editPageId="org.eclipse.jdt.ui.JavaWorkingSetPage" id="1518877537370_6" label="utils" name="utils">
+<workingSets editPageId="org.eclipse.jdt.ui.JavaWorkingSetPage" id="1518877537370_6" label="core-utils" name="utils">
 <item elementID="=org.moflon.core.plugins" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
 <item elementID="=org.moflon.core.utilities" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
 <item elementID="=org.moflon.core.plugins.tests" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>


### PR DESCRIPTION
- Updates the project set such that the names of the working sets are prefixed with `core`.
- `BuildPropertiesFileBuilder`: add method `createBuildProperties(IProject, IProgressMonitor, Properties)` to set a custom set of build properties. The change is backwards compatible due to `createBuildProperties(IProject, IProgressMonitor)` calling the new method with the default eMoflon build properties.
- `WorkspaceHelper`: Add a method collecting all URIs to the `.ecore` files of eMoflon EMF Projects