### PR TITLE
Updates runtime files to JavaSE-17

### DIFF
--- a/org.moflon.core.build/src/org/moflon/core/build/MoflonProjectCreator.java
+++ b/org.moflon.core.build/src/org/moflon/core/build/MoflonProjectCreator.java
@@ -182,7 +182,7 @@ public abstract class MoflonProjectCreator extends WorkspaceTask implements Proj
 			changed |= ManifestFileUpdater.updateAttribute(manifest, PluginManifestConstants.BUNDLE_ACTIVATION_POLICY,
 					"lazy", AttributeUpdatePolicy.KEEP);
 			changed |= ManifestFileUpdater.updateAttribute(manifest,
-					PluginManifestConstants.BUNDLE_EXECUTION_ENVIRONMENT, "JavaSE-16", AttributeUpdatePolicy.FORCE);
+					PluginManifestConstants.BUNDLE_EXECUTION_ENVIRONMENT, "JavaSE-17", AttributeUpdatePolicy.FORCE);
 			changed |= ManifestFileUpdater.updateAttribute(manifest, PluginManifestConstants.AUTOMATIC_MODULE_NAME,
 					pluginId, AttributeUpdatePolicy.KEEP);
 			return changed;

--- a/org.moflon.core.plugins/src/org/moflon/core/plugins/PluginProducerWorkspaceRunnable.java
+++ b/org.moflon.core.plugins/src/org/moflon/core/plugins/PluginProducerWorkspaceRunnable.java
@@ -101,7 +101,7 @@ public class PluginProducerWorkspaceRunnable implements IWorkspaceRunnable {
 			changed |= ManifestFileUpdater.updateAttribute(manifest, PluginManifestConstants.BUNDLE_ACTIVATION_POLICY,
 					"lazy", AttributeUpdatePolicy.KEEP);
 			changed |= ManifestFileUpdater.updateAttribute(manifest,
-					PluginManifestConstants.BUNDLE_EXECUTION_ENVIRONMENT, "JavaSE-16", AttributeUpdatePolicy.FORCE);
+					PluginManifestConstants.BUNDLE_EXECUTION_ENVIRONMENT, "JavaSE-17", AttributeUpdatePolicy.FORCE);
 
 			changed |= ManifestFileUpdater.updateDependencies(manifest, Arrays
 					.asList(new String[] { WorkspaceHelper.PLUGIN_ID_ECORE, WorkspaceHelper.PLUGIN_ID_ECORE_XMI }));

--- a/org.moflon.core.plugins/src/org/moflon/core/plugins/manifest/ManifestFileUpdater.java
+++ b/org.moflon.core.plugins/src/org/moflon/core/plugins/manifest/ManifestFileUpdater.java
@@ -410,7 +410,7 @@ public class ManifestFileUpdater {
 		changed |= ManifestFileUpdater.updateAttribute(manifest, PluginManifestConstants.BUNDLE_ACTIVATION_POLICY,
 				"lazy", AttributeUpdatePolicy.KEEP);
 		changed |= ManifestFileUpdater.updateAttribute(manifest, PluginManifestConstants.BUNDLE_EXECUTION_ENVIRONMENT,
-				"JavaSE-16", AttributeUpdatePolicy.FORCE);
+				"JavaSE-17", AttributeUpdatePolicy.FORCE);
 		return changed;
 	}
 


### PR DESCRIPTION
eMoflon uses Java 17 (e.g., https://github.com/eMoflon/emoflon-core/blob/master/org.moflon.core.ui/META-INF/MANIFEST.MF#L6) --> The runtime projects should at least use Java 17, too.