### PR TITLE
Fix XMI save bug: Absolute paths on Windows (`C:\$project`) + exceptions on Linux (`/$project`)

### DIFF
--- a/emfcodegenerator/src/org/emoflon/smartemf/persistence/JDOMXmiParser.java
+++ b/emfcodegenerator/src/org/emoflon/smartemf/persistence/JDOMXmiParser.java
@@ -34,38 +34,38 @@ import org.jdom2.Namespace;
 import org.jdom2.input.SAXBuilder;
 
 public class JDOMXmiParser {
-
+	
 	protected final String workspacePath;
-
+	
 	protected Map<String, List<Consumer<EObject>>> waitingCrossRefs = new HashMap<>();
 	protected Map<String, List<Consumer<EObject>>> waitingHRefs = new HashMap<>();
 	protected Map<String, EObject> id2Object = new HashMap<>();
 	protected Map<String, EObject> fqId2Object = new HashMap<>();
 	protected Map<String, EPackage> ns2Package = new HashMap<>();
 	protected Map<String, EFactory> ns2Factory = new HashMap<>();
-	protected Map<String, Resource> loadedResources = new HashMap<>();
+	protected Map<String, Resource> loadedResources = new HashMap<>(); 
 	protected URI initialUri = null;
-
+	
 	public JDOMXmiParser(final String workspacePath) {
 		this.workspacePath = workspacePath;
 	}
-
+	
 	public Map<String, Resource> getLoadedResources() {
 		return loadedResources;
 	}
-
+	
 	public Map<String, EObject> getFqId2ObjectMap() {
 		return fqId2Object;
 	}
-
+	
 	public void addWaitingHRefs(final Map<String, List<Consumer<EObject>>> hrefs) {
 		waitingHRefs.putAll(hrefs);
 	}
-
+	
 	public Map<String, List<Consumer<EObject>>> getWaitingHRefs() {
 		return waitingHRefs;
 	}
-
+	
 	public void load(final InputStream is, final Resource resource) throws Exception {
 		SAXBuilder saxBuilder = new SAXBuilder();
 		Document parsedFile = null;
@@ -74,67 +74,63 @@ public class JDOMXmiParser {
 		} catch (JDOMException | IOException e) {
 			throw new IOException(e.getMessage(), e.getCause());
 		}
-
-		if (initialUri == null) {
-			String resolvedPath = XmiParserUtil.resolveURIToPath(resource.getURI(), workspacePath, false);
+		
+		if(initialUri == null) {
+			String resolvedPath = XmiParserUtil.resolveURIToPath(resource.getURI(), workspacePath);
 			initialUri = URI.createFileURI(resolvedPath);
 		}
-
+		
 		domTreeToModel(parsedFile, resource);
 		loadedResources.put(resource.getURI().toString(), resource);
 	}
-
-	public Resource load(final String uri, final ResourceSet rs) throws Exception {
+	
+	public Resource load(final String uri, final ResourceSet rs) throws Exception{	
 		String filePath = XmiParserUtil.resolveURIRelativeToBaseURI(initialUri, URI.createURI(uri), workspacePath);
-		if (filePath == null)
-			throw new FileNotFoundException("Relative path " + uri.trim().replace("%20", " ")
-					+ " could not be resolved with the path of the initial uri "
-					+ initialUri.devicePath().trim().replace("%20", " ") + ".");
-
+		if(filePath == null)
+			throw new FileNotFoundException("Relative path "+uri.trim().replace("%20", " ")+" could not be resolved with the path of the initial uri "+initialUri.devicePath().trim().replace("%20", " ")+".");
+		
 		Resource resource = null;
-		for (Resource loadedResource : rs.getResources()) {
-			if (XmiParserUtil.relativeURIsAreEqual(initialUri, URI.createURI(uri), loadedResource.getURI(),
-					workspacePath)) {
+		for(Resource loadedResource : rs.getResources()) {
+			if(XmiParserUtil.relativeURIsAreEqual(initialUri, URI.createURI(uri), loadedResource.getURI(), workspacePath)) {
 				resource = loadedResource;
 				break;
 			}
 		}
-		if (resource == null) {
+		if(resource == null) {
 			File file = new File(filePath);
 			FileInputStream fis = new FileInputStream(file);
 			resource = new SmartEMFResource(URI.createFileURI(file.getCanonicalPath()), workspacePath);
 			rs.getResources().add(resource);
-
+			
 			JDOMXmiParser subParser = new JDOMXmiParser(workspacePath);
 			subParser.addWaitingHRefs(waitingHRefs);
 			subParser.load(fis, resource);
 			fis.close();
-
-			loadedResources.putAll(subParser.getLoadedResources());
+			
+			loadedResources.putAll(subParser.getLoadedResources());			
 			fqId2Object.putAll(subParser.getFqId2ObjectMap());
 			waitingHRefs.putAll(subParser.getWaitingHRefs());
 		} else {
 			indexForeignResource(resource);
 		}
-
+		
 		loadedResources.put(uri, resource);
 		return resource;
 	}
-
+	
 	public void domTreeToModel(final Document domTree, final Resource resource) throws Exception {
 		Element root = domTree.getRootElement();
 		Namespace ns = root.getNamespace();
 		List<Element> roots = new LinkedList<>();
-		// If there is a root node belonging to the XMI Namespace, than we have multiple
-		// container objects wrapped within an XML dummy-node to ensure XML compliance
-		if (XmiParserUtil.XMI_NS.equals(ns.getPrefix())) {
+		// If there is a root node belonging to the XMI Namespace, than we have multiple container objects wrapped within an XML dummy-node to ensure XML compliance
+		if(XmiParserUtil.XMI_NS.equals(ns.getPrefix())) {
 			roots.addAll(root.getChildren());
 		} else {
 			roots.add(root);
 		}
-
+		
 		int id = 0;
-		for (Element subRoot : roots) {
+		for(Element subRoot : roots) {
 			// Load the corresponding metamodel and factory
 			Namespace subRootNS = subRoot.getNamespace();
 			EPackage metamodel = XmiParserUtil.loadMetamodel(subRootNS.getURI());
@@ -143,39 +139,35 @@ public class JDOMXmiParser {
 			ns2Factory.put(subRootNS.getPrefix(), factory);
 			// find additional namespaces
 			Set<Namespace> additionalNS = subRoot.getAdditionalNamespaces().stream()
-					.filter(ns2 -> !ns2.getPrefix().equals(XmiParserUtil.XMI_NS)
-							&& !ns2.getPrefix().equals(XmiParserUtil.XSI_NS)
-							&& !ns2.getPrefix().equals(subRootNS.getPrefix()))
-					.filter(ns2 -> !ns2Package.containsKey(ns2.getPrefix())).collect(Collectors.toSet());
-
-			for (Namespace ns2 : additionalNS) {
+				.filter(ns2 -> !ns2.getPrefix().equals(XmiParserUtil.XMI_NS) && !ns2.getPrefix().equals(XmiParserUtil.XSI_NS) && !ns2.getPrefix().equals(subRootNS.getPrefix()))
+				.filter(ns2 -> !ns2Package.containsKey(ns2.getPrefix()))
+				.collect(Collectors.toSet());
+			
+			for(Namespace ns2 : additionalNS) {
 				EPackage additionalMetamodel = XmiParserUtil.loadMetamodel(ns2.getURI());
 				EFactory additionalFactory = additionalMetamodel.getEFactoryInstance();
 				ns2Package.put(ns2.getPrefix(), additionalMetamodel);
 				ns2Factory.put(ns2.getPrefix(), additionalFactory);
 			}
-
+			
 			// traverse tree and instantiate classes
 			EObject eRoot = null;
-			if (roots.size() > 1) {
-				eRoot = parseDomTree(resource, subRoot, null, subRootNS.getPrefix(),
-						resource.getURI().toString() + "#/" + id, "/" + id, 0);
+			if(roots.size() > 1) {
+				eRoot = parseDomTree(resource, subRoot, null, subRootNS.getPrefix(), resource.getURI().toString()+"#/"+id, "/"+id, 0);
 				id++;
 			} else {
-				eRoot = parseDomTree(resource, subRoot, null, subRootNS.getPrefix(),
-						resource.getURI().toString() + "#/", "/", 0);
+				eRoot = parseDomTree(resource, subRoot, null, subRootNS.getPrefix(), resource.getURI().toString()+"#/", "/", 0);
 			}
 			resource.getContents().add(eRoot);
 		}
-
+		
 	}
-
+	
 	@SuppressWarnings("unchecked")
-	protected EObject parseDomTree(final Resource resource, Element root, EReference containment, String namespace,
-			String fqId, String id, int idx) throws Exception {
+	protected EObject parseDomTree(final Resource resource, Element root, EReference containment, String namespace, String fqId, String id, int idx) throws Exception {
 		EPackage metamodel = null;
 		String currentNamespace = null;
-		if (root.getNamespace().getPrefix() == null || root.getNamespace().getPrefix().isBlank()) {
+		if(root.getNamespace().getPrefix() == null || root.getNamespace().getPrefix().isBlank()) {
 			metamodel = ns2Package.get(namespace);
 			currentNamespace = namespace;
 		} else {
@@ -183,116 +175,108 @@ public class JDOMXmiParser {
 			currentNamespace = root.getNamespace().getPrefix();
 		}
 		EFactory factory = ns2Factory.get(currentNamespace);
-
+		
 		EClass rootClass = null;
 		String currentId = id;
 		String currentFqId = fqId;
 		String simpleId = null;
 		String simpleFqId = null;
-
-		if (containment == null) {
-			rootClass = (EClass) metamodel.getEClassifier(root.getName());
+		
+		if(containment == null) {
+			rootClass = (EClass)metamodel.getEClassifier(root.getName());
 		} else {
 			Optional<Attribute> typeATR = root.getAttributes().stream()
-					.filter(atr -> atr.getName().equals(XmiParserUtil.XSI_TYPE)
-							&& atr.getNamespacePrefix().equals(XmiParserUtil.XSI_NS))
-					.findFirst();
-			if (typeATR.isPresent()) {
+					.filter(atr -> atr.getName().equals(XmiParserUtil.XSI_TYPE) && atr.getNamespacePrefix().equals(XmiParserUtil.XSI_NS)).findFirst();
+			if(typeATR.isPresent()) {
 				String[] exactType = typeATR.get().getValue().split(":");
-				// This is obviously an element belonging to a foreign metamodel -> switch to
-				// suitable EPacakge and Factory but stay in the current namespace
+				//This is obviously an element belonging to a foreign metamodel -> switch to suitable EPacakge and Factory but stay in the current namespace
 				String metamodelNS = exactType[0];
 				String className = exactType[1];
 				metamodel = ns2Package.get(metamodelNS);
 				factory = ns2Factory.get(metamodelNS);
-				rootClass = (EClass) metamodel.getEClassifier(className);
+				rootClass = (EClass)metamodel.getEClassifier(className);
 			} else {
 				rootClass = containment.getEReferenceType();
 			}
 			currentId = id + "/@" + containment.getName() + "." + idx;
 			currentFqId = fqId + "/@" + containment.getName() + "." + idx;
-			// This a workaround for a useless/annoying xml simplification that occurs when
-			// a child list is exactly of size 1, then the index is omitted.
-			if (idx == 0) {
+			// This a workaround for a useless/annoying xml simplification that occurs when a child list is exactly of size 1, then the index is omitted.
+			if(idx == 0) {
 				simpleId = id + "/@" + containment.getName();
 				simpleFqId = fqId + "/@" + containment.getName();
 			}
 		}
-
+		
 		EObject eRoot = factory.create(rootClass);
-
+		
 		currentId = XmiParserUtil.simplifyID(currentId);
 		currentFqId = XmiParserUtil.simplifyID(currentFqId);
-
+		
 		id2Object.put(currentId, eRoot);
 		fqId2Object.put(currentFqId, eRoot);
-
-		if (simpleId != null) {
+		
+		if(simpleId != null) {
 			simpleId = XmiParserUtil.simplifyID(simpleId);
 			simpleFqId = XmiParserUtil.simplifyID(simpleFqId);
-
+			
 			id2Object.put(simpleId, eRoot);
 			fqId2Object.put(simpleFqId, eRoot);
 		}
-
-		if (waitingCrossRefs.containsKey(currentId)) {
+			
+		if(waitingCrossRefs.containsKey(currentId)) {
 			waitingCrossRefs.get(currentId).forEach(waitingRef -> waitingRef.accept(eRoot));
 			waitingCrossRefs.remove(currentId);
 		}
-		if (simpleId != null && waitingCrossRefs.containsKey(simpleId)) {
+		if(simpleId != null && waitingCrossRefs.containsKey(simpleId)) {
 			waitingCrossRefs.get(simpleId).forEach(waitingRef -> waitingRef.accept(eRoot));
 			waitingCrossRefs.remove(simpleId);
 		}
-
-		if (waitingHRefs.containsKey(currentFqId)) {
+		
+		if(waitingHRefs.containsKey(currentFqId)) {
 			waitingHRefs.get(currentFqId).forEach(waitingRef -> waitingRef.accept(eRoot));
 			waitingHRefs.remove(currentFqId);
 		}
-
-		if (simpleFqId != null && waitingCrossRefs.containsKey(simpleFqId)) {
+		
+		if(simpleFqId != null && waitingCrossRefs.containsKey(simpleFqId)) {
 			waitingHRefs.get(simpleFqId).forEach(waitingRef -> waitingRef.accept(eRoot));
 			waitingHRefs.remove(simpleFqId);
 		}
-
-		Map<EStructuralFeature, Integer> element2Idx = new HashMap<>();
+		
+		Map<EStructuralFeature,Integer> element2Idx = new HashMap<>();
 		Map<EStructuralFeature, PendingEMFCrossReference> feature2CrossRef = new HashMap<>();
-		for (Element element : root.getChildren()) {
-			if (XmiParserUtil.XMI_NS.equals(element.getNamespace().getPrefix()))
+		for(Element element : root.getChildren()) {
+			if(XmiParserUtil.XMI_NS.equals(element.getNamespace().getPrefix()))
 				continue;
-
-			Optional<EStructuralFeature> featureOpt = rootClass.getEAllStructuralFeatures().stream()
-					.filter(sf -> sf.getName().equals(element.getName())).findFirst();
-			if (!featureOpt.isPresent())
-				throw new IOException("Unkown structual feature: " + element.getName());
-
-			EStructuralFeature feature = featureOpt.get();
-			if (feature instanceof EAttribute)
-				throw new IOException("Illegal use of EAttribute: " + element.getName());
-
-			if (!element2Idx.containsKey(feature)) {
+			
+			Optional<EStructuralFeature> featureOpt = rootClass.getEAllStructuralFeatures().stream().filter(sf -> sf.getName().equals(element.getName())).findFirst();
+			if(!featureOpt.isPresent())
+				throw new IOException("Unkown structual feature: "+element.getName());
+			
+			EStructuralFeature feature  = featureOpt.get();
+			if(feature instanceof EAttribute)
+				throw new IOException("Illegal use of EAttribute: "+element.getName());
+			
+			if(!element2Idx.containsKey(feature)) {
 				element2Idx.put(feature, 0);
 			}
-
-			EReference ref = (EReference) feature;
-			if (ref.isContainment()) {
-				if (ref.isMany()) {
+			
+			EReference ref = (EReference)feature;
+			if(ref.isContainment()) {
+				if(ref.isMany()) {
 					EList<EObject> objs = (EList<EObject>) eRoot.eGet(ref);
-					EObject child = parseDomTree(resource, element, ref, currentNamespace, currentFqId, currentId,
-							element2Idx.get(feature));
+					EObject child = parseDomTree(resource, element, ref, currentNamespace, currentFqId, currentId, element2Idx.get(feature));
 					objs.add(child);
-					element2Idx.replace(feature, element2Idx.get(feature) + 1);
+					element2Idx.replace(feature, element2Idx.get(feature)+1);
 				} else {
-					EObject child = parseDomTree(resource, element, ref, currentNamespace, currentFqId, currentId,
-							element2Idx.get(feature));
+					EObject child = parseDomTree(resource, element, ref, currentNamespace, currentFqId, currentId, element2Idx.get(feature));
 					eRoot.eSet(ref, child);
-					element2Idx.replace(feature, element2Idx.get(feature) + 1);
+					element2Idx.replace(feature, element2Idx.get(feature)+1);
 				}
 			} else {
-				if (XmiParserUtil.isHyperref(element)) {
+				if(XmiParserUtil.isHyperref(element)) {
 					PendingEMFCrossReference pendingCrossref = feature2CrossRef.get(ref);
-					if (pendingCrossref == null) {
-						pendingCrossref = new PendingEMFCrossReference(eRoot, ref, (int) root.getChildren().stream()
-								.filter(elt -> elt.getName().equals(ref.getName())).count());
+					if(pendingCrossref == null) {
+						pendingCrossref = new PendingEMFCrossReference(eRoot, ref, (int)root.getChildren().stream().filter(elt -> elt.getName().equals(ref.getName())).count());
 						feature2CrossRef.put(ref, pendingCrossref);
 					}
 					Attribute href = element.getAttribute(XmiParserUtil.HREF_ATR);
@@ -300,210 +284,195 @@ public class JDOMXmiParser {
 					String modelUri = hrefPath[0];
 					String hrefFQId = null;
 					Resource otherResource = null;
-
-					if (!loadedResources.containsKey(modelUri)) {
+					
+					if(!loadedResources.containsKey(modelUri)) {
 						otherResource = load(modelUri, resource.getResourceSet());
-
+						
 					} else {
 						otherResource = loadedResources.get(modelUri);
 					}
-					hrefFQId = otherResource.getURI().toString() + "#" + hrefPath[1];
+					hrefFQId = otherResource.getURI().toString()+"#"+hrefPath[1];
 					hrefFQId = XmiParserUtil.simplifyID(hrefFQId);
-
-					if (fqId2Object.containsKey(hrefFQId)) {
+					
+					if(fqId2Object.containsKey(hrefFQId))  {
 						EObject hyperref = fqId2Object.get(hrefFQId);
-
-						if (ref.isMany()) {
+						
+						if(ref.isMany()) {
 							pendingCrossref.insertObject(hyperref, element2Idx.get(feature));
-							element2Idx.replace(feature, element2Idx.get(feature) + 1);
+							element2Idx.replace(feature, element2Idx.get(feature)+1);
 						} else {
 							pendingCrossref.insertObject(hyperref, 0);
 						}
-
-						if (pendingCrossref.isCompleted()) {
+						
+						if(pendingCrossref.isCompleted()) {
 							pendingCrossref.writeBack();
 						}
 					} else {
 						List<Consumer<EObject>> pendingHRefs = waitingHRefs.get(hrefFQId);
-						if (pendingHRefs == null) {
+						if(pendingHRefs == null) {
 							pendingHRefs = new LinkedList<>();
 							waitingHRefs.put(hrefFQId, pendingHRefs);
 						}
-
+						
 						// Make those variables final 'cause java ..
 						final int currentIdx = element2Idx.get(feature);
 						final PendingEMFCrossReference currentPending = pendingCrossref;
 						pendingHRefs.add((eobj) -> {
 							currentPending.insertObject(eobj, currentIdx);
-							if (currentPending.isCompleted()) {
+							if(currentPending.isCompleted()) {
 								currentPending.writeBack();
 							}
 						});
-						element2Idx.replace(feature, element2Idx.get(feature) + 1);
+						element2Idx.replace(feature, element2Idx.get(feature)+1);
 					}
 				} else {
-					throw new IOException("XML DOM-Tree child: " + element.getName()
-							+ " is neither, a hyperref nor in a containment!");
+					throw new IOException("XML DOM-Tree child: "+element.getName()+" is neither, a hyperref nor in a containment!");
 				}
-
+				
 			}
 		}
-
-		for (Attribute attribute : root.getAttributes()) {
-			if (XmiParserUtil.XMI_NS.equals(attribute.getNamespace().getPrefix()))
+		
+		for(Attribute attribute : root.getAttributes()) {
+			if(XmiParserUtil.XMI_NS.equals(attribute.getNamespace().getPrefix()))
 				continue;
-
-			if (XmiParserUtil.XSI_NS.equals(attribute.getNamespace().getPrefix()))
+			
+			if(XmiParserUtil.XSI_NS.equals(attribute.getNamespace().getPrefix()))
 				continue;
-
-			Optional<EStructuralFeature> featureOpt = rootClass.getEAllStructuralFeatures().stream()
-					.filter(sf -> sf.getName().equals(attribute.getName())).findFirst();
-			if (!featureOpt.isPresent())
-				throw new IOException("Unkown structual feature: " + attribute.getName());
-
-			EStructuralFeature feature = featureOpt.get();
-			if (feature instanceof EReference) {
-				EReference ref = (EReference) feature;
-				if (attribute.getValue().isBlank())
+			
+			Optional<EStructuralFeature> featureOpt = rootClass.getEAllStructuralFeatures().stream().filter(sf -> sf.getName().equals(attribute.getName())).findFirst();
+			if(!featureOpt.isPresent())
+				throw new IOException("Unkown structual feature: "+attribute.getName());
+			
+			EStructuralFeature feature  = featureOpt.get();
+			if(feature instanceof EReference) {
+				EReference ref = (EReference)feature;
+				if(attribute.getValue().isBlank())
 					continue;
-
+				
 				String[] entries = attribute.getValue().split(" ");
-				final PendingEMFCrossReference pendingCrossRefs = new PendingEMFCrossReference(eRoot, ref,
-						entries.length);
-				for (int i = 0; i < entries.length; i++) {
-					String entry = (entries[i].contains("#")) ? entries[i].split("#")[1] : entries[i];
+				final PendingEMFCrossReference pendingCrossRefs = new PendingEMFCrossReference(eRoot, ref, entries.length);
+				for(int i = 0; i<entries.length; i++) {
+					String entry = (entries[i].contains("#"))?entries[i].split("#")[1]:entries[i];
 					entry = XmiParserUtil.simplifyID(entry);
-					if (ref.isMany()) {
-						if (id2Object.containsKey(entry)) {
+					if(ref.isMany()) {
+						if(id2Object.containsKey(entry)) {
 							pendingCrossRefs.insertObject(id2Object.get(entry), i);
 						} else {
 							// Remember this crossRef and wait for traversal
 							List<Consumer<EObject>> otherCrossRefs = waitingCrossRefs.get(entry);
-							if (otherCrossRefs == null) {
+							if(otherCrossRefs == null) {
 								otherCrossRefs = new LinkedList<>();
 								waitingCrossRefs.put(entry, otherCrossRefs);
 							}
 							final int currentIdx = i;
 							otherCrossRefs.add((eobj) -> {
 								pendingCrossRefs.insertObject(eobj, currentIdx);
-								if (pendingCrossRefs.isCompleted())
+								if(pendingCrossRefs.isCompleted())
 									pendingCrossRefs.writeBack();
 							});
 						}
 					} else {
-						if (id2Object.containsKey(entry)) {
+						if(id2Object.containsKey(entry)) {
 							pendingCrossRefs.insertObject(id2Object.get(entry), 0);
 						} else {
 							// Remember this crossRef and wait for traversal
 							List<Consumer<EObject>> otherCrossRefs = waitingCrossRefs.get(entry);
-							if (otherCrossRefs == null) {
+							if(otherCrossRefs == null) {
 								otherCrossRefs = new LinkedList<>();
 								waitingCrossRefs.put(entry, otherCrossRefs);
 							}
 							otherCrossRefs.add((eobj) -> {
 								pendingCrossRefs.insertObject(eobj, 0);
-								if (pendingCrossRefs.isCompleted())
+								if(pendingCrossRefs.isCompleted())
 									pendingCrossRefs.writeBack();
 							});
 						}
 					}
 				}
-				if (pendingCrossRefs.isCompleted())
+				if(pendingCrossRefs.isCompleted())
 					pendingCrossRefs.writeBack();
-
+				
 			} else {
 				EAttribute eAttribute = (EAttribute) feature;
-
-				switch (attribute.getAttributeType()) {
+				
+				switch(attribute.getAttributeType()) {
 				case CDATA:
 					eRoot.eSet(eAttribute, XmiParserUtil.stringToValue(eAttribute, attribute.getValue()));
 					break;
 				case ENTITIES:
-					throw new IOException("Unsupported XML attribute type: " + attribute.getAttributeType()
-							+ " for attribute: " + attribute.getName());
+					throw new IOException("Unsupported XML attribute type: "+attribute.getAttributeType()+" for attribute: "+attribute.getName());
 				case ENTITY:
-					throw new IOException("Unsupported XML attribute type: " + attribute.getAttributeType()
-							+ " for attribute: " + attribute.getName());
+					throw new IOException("Unsupported XML attribute type: "+attribute.getAttributeType()+" for attribute: "+attribute.getName());
 				case ENUMERATION:
-					throw new IOException("Unsupported XML attribute type: " + attribute.getAttributeType()
-							+ " for attribute: " + attribute.getName());
+					throw new IOException("Unsupported XML attribute type: "+attribute.getAttributeType()+" for attribute: "+attribute.getName());
 				case ID:
-					throw new IOException("Unsupported XML attribute type: " + attribute.getAttributeType()
-							+ " for attribute: " + attribute.getName());
+					throw new IOException("Unsupported XML attribute type: "+attribute.getAttributeType()+" for attribute: "+attribute.getName());
 				case IDREF:
-					throw new IOException("Unsupported XML attribute type: " + attribute.getAttributeType()
-							+ " for attribute: " + attribute.getName());
+					throw new IOException("Unsupported XML attribute type: "+attribute.getAttributeType()+" for attribute: "+attribute.getName());
 				case IDREFS:
-					throw new IOException("Unsupported XML attribute type: " + attribute.getAttributeType()
-							+ " for attribute: " + attribute.getName());
+					throw new IOException("Unsupported XML attribute type: "+attribute.getAttributeType()+" for attribute: "+attribute.getName());
 				case NMTOKEN:
-					throw new IOException("Unsupported XML attribute type: " + attribute.getAttributeType()
-							+ " for attribute: " + attribute.getName());
+					throw new IOException("Unsupported XML attribute type: "+attribute.getAttributeType()+" for attribute: "+attribute.getName());
 				case NMTOKENS:
-					throw new IOException("Unsupported XML attribute type: " + attribute.getAttributeType()
-							+ " for attribute: " + attribute.getName());
+					throw new IOException("Unsupported XML attribute type: "+attribute.getAttributeType()+" for attribute: "+attribute.getName());
 				case NOTATION:
-					throw new IOException("Unsupported XML attribute type: " + attribute.getAttributeType()
-							+ " for attribute: " + attribute.getName());
+					throw new IOException("Unsupported XML attribute type: "+attribute.getAttributeType()+" for attribute: "+attribute.getName());
 				case UNDECLARED:
-					throw new IOException("Unsupported XML attribute type: " + attribute.getAttributeType()
-							+ " for attribute: " + attribute.getName());
+					throw new IOException("Unsupported XML attribute type: "+attribute.getAttributeType()+" for attribute: "+attribute.getName());
 				default:
-					throw new IOException("Unsupported XML attribute type: " + attribute.getAttributeType()
-							+ " for attribute: " + attribute.getName());
-
+					throw new IOException("Unsupported XML attribute type: "+attribute.getAttributeType()+" for attribute: "+attribute.getName());
+				
 				}
 			}
 
 		}
 		return eRoot;
 	}
-
+	
 	protected void indexForeignResource(final Resource resource) {
-		if (resource.getContents().size() < 2) {
-			indexForeignModel(resource.getContents().get(0), null, resource.getURI().toString() + "#/", 0, false);
+		if(resource.getContents().size() < 2) {
+			indexForeignModel(resource.getContents().get(0), null, resource.getURI().toString()+"#/", 0, false);
 		} else {
 			int idx = 0;
-			for (EObject container : resource.getContents()) {
-				indexForeignModel(container, null, resource.getURI().toString() + "#/" + idx++, 0, false);
+			for(EObject container : resource.getContents()) {
+				indexForeignModel(container, null, resource.getURI().toString()+"#/"+idx++, 0, false);
 			}
 		}
-
+		
 	}
-
+	
 	@SuppressWarnings("unchecked")
-	protected void indexForeignModel(final EObject root, final EReference containment, final String id, int idx,
-			boolean useSimple) {
+	protected void indexForeignModel(final EObject root, final EReference containment, final String id, int idx, boolean useSimple) {
 		EClass rootClass = root.eClass();
 		String rootId = id;
-		if (containment != null) {
-			if (useSimple) {
+		if(containment != null) {
+			if(useSimple) {
 				rootId = id + "/@" + containment.getName();
 			} else {
 				rootId = id + "/@" + containment.getName() + "." + idx;
 			}
 		}
 		rootId = XmiParserUtil.simplifyID(rootId);
-
+		
 		fqId2Object.put(rootId, root);
-		if (waitingHRefs.containsKey(rootId)) {
+		if(waitingHRefs.containsKey(rootId)) {
 			waitingHRefs.get(rootId).forEach(waitingRef -> waitingRef.accept(root));
 			waitingHRefs.remove(rootId);
 		}
-
+		
 		// Containments
-		for (EReference containmentRef : rootClass.getEAllContainments()) {
+		for(EReference containmentRef : rootClass.getEAllContainments()) {
 			List<EObject> containees = new LinkedList<>();
-			if (containmentRef.isMany()) {
+			if(containmentRef.isMany()) {
 				containees.addAll((Collection<? extends EObject>) root.eGet(containmentRef));
 			} else {
 				EObject containee = (EObject) root.eGet(containmentRef);
-				if (containee != null)
+				if(containee != null)
 					containees.add(containee);
 			}
 			int idIDX = 0;
-			for (EObject containee : containees) {
-				indexForeignModel(containee, containmentRef, rootId, idIDX, containees.size() == 1);
+			for(EObject containee : containees) {
+				indexForeignModel(containee, containmentRef, rootId, idIDX, containees.size()==1);
 				idIDX++;
 			}
 		}

--- a/emfcodegenerator/src/org/emoflon/smartemf/persistence/SmartEMFResource.java
+++ b/emfcodegenerator/src/org/emoflon/smartemf/persistence/SmartEMFResource.java
@@ -30,8 +30,8 @@ import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
 
 /**
- * A simplified resource implementation that serializes to XMI. Ignores save
- * options. Can enable notification cascading for its contents.
+ * A simplified resource implementation that serializes to XMI. Ignores save options. Can enable
+ * notification cascading for its contents.
  */
 public class SmartEMFResource extends UnlockedResourceImpl implements XMIResource {
 
@@ -69,7 +69,7 @@ public class SmartEMFResource extends UnlockedResourceImpl implements XMIResourc
 
 	@Override
 	public void save(Map<?, ?> options) throws IOException {
-		String path = XmiParserUtil.resolveURIToPath(uri, workspacePath, true);
+		String path = XmiParserUtil.resolveURIToPath(uri, workspacePath);
 
 		if (path == null)
 			throw new FileNotFoundException("Invalid path at: " + uri);
@@ -90,8 +90,7 @@ public class SmartEMFResource extends UnlockedResourceImpl implements XMIResourc
 	@Override
 	public void save(OutputStream outputStream, Map<?, ?> options) throws IOException {
 
-		URIConverter.Cipher cipher = (options != null) ? (URIConverter.Cipher) options.get(Resource.OPTION_CIPHER)
-				: null;
+		URIConverter.Cipher cipher = (options != null) ? (URIConverter.Cipher) options.get(Resource.OPTION_CIPHER) : null;
 		if (cipher != null) {
 			throw new UnsupportedOperationException("Encryption through cipher is not supported!");
 		}
@@ -120,7 +119,7 @@ public class SmartEMFResource extends UnlockedResourceImpl implements XMIResourc
 
 	@Override
 	public void load(Map<?, ?> options) throws IOException {
-		String path = XmiParserUtil.resolveURIToPath(uri, workspacePath, false);
+		String path = XmiParserUtil.resolveURIToPath(uri, workspacePath);
 		if (path == null)
 			throw new FileNotFoundException("No valid xmi file present at: " + uri);
 
@@ -147,8 +146,7 @@ public class SmartEMFResource extends UnlockedResourceImpl implements XMIResourc
 		Notification notification = setLoaded(true);
 		isLoading = true;
 
-		URIConverter.Cipher cipher = (options != null) ? (URIConverter.Cipher) options.get(Resource.OPTION_CIPHER)
-				: null;
+		URIConverter.Cipher cipher = (options != null) ? (URIConverter.Cipher) options.get(Resource.OPTION_CIPHER) : null;
 		if (cipher != null) {
 			throw new UnsupportedOperationException("Encryption through cipher is not supported!");
 		}

--- a/emfcodegenerator/src/org/emoflon/smartemf/persistence/XmiParserUtil.java
+++ b/emfcodegenerator/src/org/emoflon/smartemf/persistence/XmiParserUtil.java
@@ -27,8 +27,8 @@ public final class XmiParserUtil {
 	final public static String HREF_ATR = "href";
 
 	public static boolean URIsAreEqual(final URI uri1, final URI uri2, final String workspacePath) {
-		String path1 = resolveURIToPath(uri1, workspacePath, false);
-		String path2 = resolveURIToPath(uri2, workspacePath, false);
+		String path1 = resolveURIToPath(uri1, workspacePath);
+		String path2 = resolveURIToPath(uri2, workspacePath);
 		return path1.equals(path2);
 	}
 
@@ -39,7 +39,7 @@ public final class XmiParserUtil {
 		return path1.equals(path2);
 	}
 
-	public static String resolveURIToPath(final URI uri, final String workspacePath, boolean newFile) {
+	public static String resolveURIToPath(final URI uri, final String workspacePath) {
 		String path = uri.devicePath();
 		if (path.startsWith("/resource")) {
 			path = path.replaceFirst("/resource", " ");
@@ -56,18 +56,6 @@ public final class XmiParserUtil {
 					return file.getCanonicalPath();
 				} catch (IOException e) {
 				}
-			}
-		}
-
-		// This might be a new file that has not existed before
-		if (newFile) {
-			File parentFolder = new File(parent);
-			if (!parentFolder.exists())
-				parentFolder.mkdirs();
-
-			try {
-				return file.getCanonicalPath();
-			} catch (IOException e) {
 			}
 		}
 
@@ -109,7 +97,7 @@ public final class XmiParserUtil {
 	}
 
 	public static String resolveURIRelativeToBaseURI(final URI baseUri, final URI uri, final String workspacePath) {
-		String filePath = resolveURIToPath(uri, workspacePath, false);
+		String filePath = resolveURIToPath(uri, workspacePath);
 		if (filePath != null)
 			return filePath;
 


### PR DESCRIPTION
Revert "+ added flag to allow creation of files that have not been there before during the save process of a smart-resource"

This reverts commit 6dde13825a97a039692c6cef6de6ae2382b2a8be.