### PR TITLE
Incompatibility with `Xtext v2.33.0` and `MWE2 v2.16.0`: Fixes broken dependencies

### DIFF
--- a/org.emoflon.core.dependencies/META-INF/MANIFEST.MF
+++ b/org.emoflon.core.dependencies/META-INF/MANIFEST.MF
@@ -94,6 +94,6 @@ Require-Bundle: com.google.guava;visibility:=reexport,
  org.eclipse.emf.ecore;bundle-version="2.19.0";visibility:=reexport,
  org.eclipse.emf.ecore.editor;bundle-version="2.17.0";visibility:=reexport,
  org.eclipse.emf.ecore.xmi;bundle-version="2.16.0";visibility:=reexport,
- org.eclipse.xtend;bundle-version="2.2.0";visibility:=reexport,
+ org.eclipse.xtend.core;bundle-version="2.2.0";visibility:=reexport,
  org.eclipse.xtend.lib;bundle-version="2.19.0";visibility:=reexport,
  org.eclipse.xtend.lib.macro;visibility:=reexport

--- a/org.moflon.core.propertycontainer/META-INF/MANIFEST.MF
+++ b/org.moflon.core.propertycontainer/META-INF/MANIFEST.MF
@@ -12,7 +12,10 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.8.0",
  org.eclipse.emf.ecore.xmi,
  org.eclipse.emf.ecore;visibility:=reexport,
  org.eclipse.emf.mwe2.launch,
- org.apache.commons.logging
+ org.apache.commons.logging,
+ org.eclipse.emf.mwe2.lib,
+ org.eclipse.emf.codegen,
+ org.eclipse.emf.codegen.ecore
 Bundle-ManifestVersion: 2
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/org.moflon.core.propertycontainer/build.properties
+++ b/org.moflon.core.propertycontainer/build.properties
@@ -4,5 +4,4 @@ bin.includes = META-INF/,\
                src/,\
                plugin.xml,\
                gen/
-additional.bundles = org.eclipse.xtext.xbase,\
-                     org.eclipse.xtext.generator
+additional.bundles = org.eclipse.xtext.xbase


### PR DESCRIPTION
This PR helps towards closing https://github.com/eMoflon/emoflon-ibex/issues/420.