### PR TITLE
Adds missing `.settings` folder with Java 21 definition for the SmartEMF project

### DIFF
--- a/org.emoflon.smartemf/.gitignore
+++ b/org.emoflon.smartemf/.gitignore
@@ -3,5 +3,4 @@
 **.class
 /bin/
 /xtend-gen/
-/.settings/
 /local-test-src/

--- a/org.emoflon.smartemf/.settings/org.eclipse.jdt.core.prefs
+++ b/org.emoflon.smartemf/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=21
+org.eclipse.jdt.core.compiler.compliance=21
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=21


### PR DESCRIPTION
Without these project-specific settings, Eclipse could produce a JAR file with higher runtime requirements than Java 21, which can not be executed on systems with Java 21.